### PR TITLE
fix: outlined scenario results merged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.vscode
 /bench-*.txt
 /vendor
+
+allure-results

--- a/_testdata/Outline.feature
+++ b/_testdata/Outline.feature
@@ -1,0 +1,21 @@
+Feature: that passes
+
+  Scenario Outline: 1 scenario 10 results
+    When I pass
+    And I sleep for a bit
+    Then I <begin>
+    And I <end>
+
+        Examples:
+            | begin | end  |
+            | fail  | pass |
+            | pass  | pass |
+            | fail  | pass |
+            | pass  | pass |
+            | fail  | pass |
+            | pass  | pass |
+            | fail  | pass |
+            | pass  | pass |
+            | fail  | pass |
+            | pass  | pass |
+

--- a/formatter.go
+++ b/formatter.go
@@ -82,9 +82,10 @@ type scenarioContext struct {
 // Pickle receives scenario.
 func (f *formatter) Pickle(scenario *godog.Scenario) {
 	feature := f.Storage.MustGetFeature(scenario.Uri)
+	uid := uuid.New().String()
 	res := report.Result{
 		Name:        scenario.Name,
-		HistoryID:   feature.Feature.Name + ": " + scenario.Name,
+		HistoryID:   feature.Feature.Name + ": " + scenario.Name + " (" + uid + ")",
 		FullName:    scenario.Uri + ":" + scenario.Name,
 		Description: scenario.Uri,
 		Labels: []report.Label{
@@ -94,7 +95,7 @@ func (f *formatter) Pickle(scenario *godog.Scenario) {
 			{Name: "language", Value: "Go"},
 		},
 		Start: report.GetTimestampMs(),
-		UUID:  uuid.New().String(),
+		UUID:  uid,
 	}
 
 	f.mu.Lock()


### PR DESCRIPTION
# issue

When use `scenario outline`, the multiple results generated by `examples` will be displayed as one, for they have the same `HistoryID`
![image](https://github.com/user-attachments/assets/07de7cd0-4390-48c8-9657-6e0071245c21)
![image](https://github.com/user-attachments/assets/f2e185a0-c418-4ec8-ac9f-f951a6bb41e4)

# fix
this fix appends `UUID` to `HistoryID` to distinguish them apart.
![image](https://github.com/user-attachments/assets/956f7dbb-5c4d-4e11-bc5e-82155d50bfdd)

