### PR TITLE
feat: support parsing Allure labels from tags

### DIFF
--- a/_testdata/Failed.feature
+++ b/_testdata/Failed.feature
@@ -1,5 +1,8 @@
+@allure.label.epic:test
+@allure.label.feature:failing
 Feature: failing scenarios
 
+  @allure.label.epic:test
   Scenario: pass then fail 1
     When I pass
     And I sleep for a bit

--- a/formatter.go
+++ b/formatter.go
@@ -82,19 +82,24 @@ type scenarioContext struct {
 // Pickle receives scenario.
 func (f *formatter) Pickle(scenario *godog.Scenario) {
 	feature := f.Storage.MustGetFeature(scenario.Uri)
+
+	labels := GetAllureLabelsFromTags(scenario.Tags)
+	labels = append(labels, []report.Label{
+		{Name: "feature", Value: feature.Feature.Name},
+		{Name: "suite", Value: f.Container.Name},
+		{Name: "epic", Value: f.Container.Name},
+		{Name: "framework", Value: "godog"},
+		{Name: "language", Value: "Go"},
+	}...)
+
 	res := report.Result{
 		Name:        scenario.Name,
 		HistoryID:   feature.Feature.Name + ": " + scenario.Name + scenario.Id,
 		FullName:    scenario.Uri + ":" + scenario.Name,
 		Description: scenario.Uri,
-		Labels: []report.Label{
-			{Name: "feature", Value: feature.Feature.Name},
-			{Name: "suite", Value: f.Container.Name},
-			{Name: "framework", Value: "godog"},
-			{Name: "language", Value: "Go"},
-		},
-		Start: report.GetTimestampMs(),
-		UUID:  uuid.New().String(),
+		Labels:      labels,
+		Start:       report.GetTimestampMs(),
+		UUID:        uuid.New().String(),
 	}
 
 	f.mu.Lock()

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,13 @@ go 1.18
 require (
 	github.com/bool64/dev v0.2.35
 	github.com/cucumber/godog v0.15.0
+	github.com/cucumber/messages/go/v21 v21.0.1
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.8.2
 )
 
 require (
 	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect
-	github.com/cucumber/messages/go/v21 v21.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect

--- a/label.go
+++ b/label.go
@@ -1,0 +1,40 @@
+package allure
+
+import (
+	"regexp"
+
+	messages "github.com/cucumber/messages/go/v21"
+	"github.com/godogx/allure/report"
+)
+
+// AllureLabelReg is a regular expression pattern for matching allure label tags.
+var AllureLabelReg = regexp.MustCompile(`^@?allure\.label\.([^.]+):(.+)$`)
+
+// MatchAllureLabel parses a tag string to extract allure label key and value.
+//
+// Examples:
+//
+//	MatchAllureLabel("@allure.label.epic:hello world") // returns "epic", "hello world", true
+//	MatchAllureLabel("allure.label.story:play")        // returns "story", "play", true
+//	MatchAllureLabel("@other.tag")                     // returns "", "", false
+func MatchAllureLabel(tag string) (key, value string, ok bool) {
+	matches := AllureLabelReg.FindStringSubmatch(tag)
+	if len(matches) != 3 {
+		return "", "", false
+	}
+
+	return matches[1], matches[2], true
+}
+
+// GetAllureLabelsFromTags parse Allure labels based on tags provided by the user.
+func GetAllureLabelsFromTags(tags []*messages.PickleTag) []report.Label {
+	var labels []report.Label
+
+	for _, tag := range tags {
+		if key, value, ok := MatchAllureLabel(tag.Name); ok {
+			labels = append(labels, report.Label{Name: key, Value: value})
+		}
+	}
+
+	return labels
+}

--- a/label_test.go
+++ b/label_test.go
@@ -1,0 +1,122 @@
+package allure_test
+
+import (
+	"testing"
+
+	messages "github.com/cucumber/messages/go/v21"
+	"github.com/godogx/allure"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchAllureLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantKey  string
+		wantVal  string
+		wantBool bool
+	}{
+		{
+			name:     "tag with @ prefix",
+			input:    "@allure.label.epic:hello world",
+			wantKey:  "epic",
+			wantVal:  "hello world",
+			wantBool: true,
+		},
+		{
+			name:     "tag without @ prefix",
+			input:    "allure.label.story:play",
+			wantKey:  "story",
+			wantVal:  "play",
+			wantBool: true,
+		},
+		{
+			name:     "non allure tag",
+			input:    "@other.tag",
+			wantKey:  "",
+			wantVal:  "",
+			wantBool: false,
+		},
+		{
+			name:     "invalid tag format",
+			input:    "@allure.label.",
+			wantKey:  "",
+			wantVal:  "",
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, val, ok := allure.MatchAllureLabel(tt.input)
+			assert.Equal(t, tt.wantKey, key)
+			assert.Equal(t, tt.wantVal, val)
+			assert.Equal(t, tt.wantBool, ok)
+		})
+	}
+}
+
+func TestGetAllureLabelsFromTags(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputTags     []*messages.PickleTag
+		expectedCount int
+		expectedTags  []struct {
+			name  string
+			value string
+		}
+	}{
+		{
+			name: "multiple valid tags",
+			inputTags: []*messages.PickleTag{
+				{Name: "@allure.label.epic:MyEpic"},
+				{Name: "@allure.label.story:MyStory"},
+				{Name: "allure.label.severity:critical"},
+			},
+			expectedCount: 3,
+			expectedTags: []struct {
+				name  string
+				value string
+			}{
+				{"epic", "MyEpic"},
+				{"story", "MyStory"},
+				{"severity", "critical"},
+			},
+		},
+		{
+			name: "mixed valid and invalid tags",
+			inputTags: []*messages.PickleTag{
+				{Name: "@some.other.tag"},
+				{Name: "@allure.label.epic:MyEpic"},
+				{Name: "not a label tag"},
+			},
+			expectedCount: 1,
+			expectedTags: []struct {
+				name  string
+				value string
+			}{
+				{"epic", "MyEpic"},
+			},
+		},
+		{
+			name:          "empty tag list",
+			inputTags:     []*messages.PickleTag{},
+			expectedCount: 0,
+			expectedTags:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := allure.GetAllureLabelsFromTags(tt.inputTags)
+			assert.Equal(t, tt.expectedCount, len(labels))
+
+			if tt.expectedCount > 0 {
+				for i, expected := range tt.expectedTags {
+					assert.Equal(t, expected.name, labels[i].Name)
+					assert.Equal(t, expected.value, labels[i].Value)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi,

In this PR, support for parsing Allure labels from tags has been added, and the test suite name is set to the value of the spec label to satisfy the [Behavior-based hierarchy](https://allurereport.org/docs/gettingstarted-navigation/#behavior-based-hierarchy) in Allure reports.